### PR TITLE
removed global timer to handle multiple uses calls

### DIFF
--- a/jquery.unevent.js
+++ b/jquery.unevent.js
@@ -7,8 +7,7 @@
  * 2013/07/26
 **/
 ;(function ($) {
-    var on = $.fn.on;
-    $.fn.on = function () {
+    $.fn.afterEvent = function () {
         var args = Array.apply(null, arguments);
         var last = args[args.length - 1];
 
@@ -25,6 +24,6 @@
             }, delay);
         });
 
-        return on.apply(this, args);
+        return $.fn.on.apply(this, args);
     };
 }(this.jQuery || this.Zepto));

--- a/jquery.unevent.js
+++ b/jquery.unevent.js
@@ -7,7 +7,7 @@
  * 2013/07/26
 **/
 ;(function ($) {
-    var on = $.fn.on, timer;
+    var on = $.fn.on;
     $.fn.on = function () {
         var args = Array.apply(null, arguments);
         var last = args[args.length - 1];
@@ -19,8 +19,8 @@
 
         args.push(function () {
             var self = this, params = arguments;
-            clearTimeout(timer);
-            timer = setTimeout(function () {
+            clearTimeout(this.timer);
+            this.timer = setTimeout(function () {
                 fn.apply(self, params);
             }, delay);
         });


### PR DESCRIPTION
Great little plugin!  Thanks for doing this!

Change info: using this for multiple events at once was causing one call to kill the timer for the other one.  attaching the timer to "this" seems to solve that problem
