### PR TITLE
Add !Number.isInteger() condition for last arg

### DIFF
--- a/jquery.unevent.js
+++ b/jquery.unevent.js
@@ -12,7 +12,7 @@
         var args = Array.apply(null, arguments);
         var last = args[args.length - 1];
 
-        if (isNaN(last) || (last === 1 && args.pop())) return on.apply(this, args);
+        if (isNaN(last) || !Number.isInteger(last) || (last === 1 && args.pop())) return on.apply(this, args);
 
         var delay = args.pop();
         var fn = args.pop();


### PR DESCRIPTION
Add condition `!Number.isInteger(last)` because from some libraries (datetimepicker) comes next: 
`var args = ["mousedown", false];`
and
`var last = false;`
But `isNaN(false) is false`.